### PR TITLE
adb_client: disable image default features

### DIFF
--- a/adb_client/Cargo.toml
+++ b/adb_client/Cargo.toml
@@ -25,7 +25,7 @@ byteorder = { version = "1.5.0" }
 chrono = { version = "0.4.40" }
 futures-lite = { version = "2.6.0", optional = true }
 homedir = { version = "0.3.4" }
-image = { version = "0.25.5" }
+image = { version = "0.25.5", default-features = false }
 lazy_static = { version = "1.5.0", optional = true }
 log = { version = "0.4.26" }
 mdns-sd = { version = "0.13.2" }


### PR DESCRIPTION
They aren't used and take a relatively long time to compile.